### PR TITLE
Allow stubs and spies to return values

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,13 @@ function ninos(test) {
 
       function stub(...args) {
         try {
+          const val = inner.call(this, ...args);
           calls.push({
             this: this,
             arguments: args,
-            return: inner.call(this, ...args),
+            return: val,
           });
+          return val;
         } catch (err) {
           calls.push({
             this: this,
@@ -41,11 +43,13 @@ function ninos(test) {
 
       function spy(...args) {
         try {
+          const val = inner.call(this, ...args);
           calls.push({
             this: this,
             arguments: args,
-            return: inner.call(this, ...args),
+            return: val,
           });
+          return val;
         } catch (err) {
           calls.push({
             this: this,

--- a/test.js
+++ b/test.js
@@ -33,6 +33,8 @@ test('t.context.stub()', t => {
 
   t.is(s.calls[3].return, undefined);
   t.true(s.calls[3].throw instanceof Error);
+
+  t.throws(s)
 });
 
 test('t.context.spy()', t => {
@@ -54,6 +56,8 @@ test('t.context.spy()', t => {
     { this: 't2', arguments: ['a2'], return: 'r2' },
     { this: 't3', arguments: ['a3'], return: 'r3' },
   ]);
+
+  t.is(object.method(), 'r2')
 });
 
 test('t.context.spy() restored after test', t => {


### PR DESCRIPTION
With the current implementation, the actual function provided by a stub or spy does not return a value regardless of what the inner function does:

```js
const math = { add: (x, y) => x + y }

test('add', t => {
  const s = t.context.spy(math, 'add')
  const sum = math.add(1, 1)
  console.log(sum) // undefined
  console.log(s.calls[0].return) // 2
})
```

When using a spy to observe the behaviour of something inside a module, I ran into trouble because the spied-on function still needed to return its value as expected.

This PR changes `stub` and `spy` so that they return whatever the inner function returns as well as pushing it to the `calls` array.

In the above example, `math.add(1, 1)` now returns `2` instead of `undefined`.

I’m fairly new to this, so I don’t know if there are other side effects or problems with returning values like this, but it is at least working for my use cases and doesn’t seem to have broken or changed other functionality. All tests still pass.

---

P.S. Thanks for documenting so clearly!